### PR TITLE
added placeholder main function to main.go in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ func init() {
 	sdfviewergo.SetRootSDF(sceneSDF())
 }
 
+//placeholder main to allow compile
+func main() {
+	fmt.Println("This is not an executable. Compile this with `" +
+		"tinygo build -o example.wasm -target wasi -opt 2 -x -no-debug ." +
+		"` and use the SDF Viewer app (github.com/Yeicor/sdf-viewer) to visualize the SDF.")
+}
+
 // sceneSDF returns the root SDF of the scene.
 func sceneSDF() sdfviewergo.SDF {
 


### PR DESCRIPTION
It seems that the readme example won't compile without a main function. I added the placeholder main from the sdfx module example and it now compiles. Using go 1.20 and tinygo 0.27.0